### PR TITLE
fixed imprecisse timing on SAMD21 (Arduino Zero)

### DIFF
--- a/.arduino-ci.yaml
+++ b/.arduino-ci.yaml
@@ -1,0 +1,11 @@
+compile:
+  platforms:
+    - uno
+    - due
+    - zero
+    - leonardo
+    - m4
+    - esp32
+    #- esp8266
+    - mega2560
+    - nano_every

--- a/.github/workflows/arduino-lint.yaml
+++ b/.github/workflows/arduino-lint.yaml
@@ -1,0 +1,16 @@
+---
+name: arduino-lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # https://github.com/actions/checkout
+      - uses: arduino/arduino-lint-action@v1
+        # https://github.com/arduino/arduino-lint-action
+        with:
+          library-manager: update
+          compliance: strict

--- a/.github/workflows/arduino_ci.yaml
+++ b/.github/workflows/arduino_ci.yaml
@@ -1,0 +1,13 @@
+---
+name: arduino_ci
+
+on: [push, pull_request]
+
+jobs:
+  arduino_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # https://github.com/actions/checkout
+      - uses: Arduino-CI/action@stable-1.x
+        # https://github.com/marketplace/actions/arduino_ci

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,3 +1,4 @@
 Naguissa - https://github.com/Naguissa
 svlPanelMaker - https://github.com/svlPanelMaker - SAMD21 timing issue fix
 Raf (Raffaele Rialdi) - https://github.com/raffaeler - ESP32 hardware timer (better precission than ticker library)
+Daniel Mohr - https://github.com/daniel-mohr - SAMD21 timing issue fix

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=uTimerLib
-version=1.7.1
+version=1.7.2
 author=Naguissa <naguissa@foroelectro.net>
 maintainer=Naguissa <naguissa@foroelectro.net>
 sentence=Tiny and cross-device compatible timer library

--- a/src/hardware/uTimerLib.SAMD21.cpp
+++ b/src/hardware/uTimerLib.SAMD21.cpp
@@ -157,7 +157,7 @@
 		while (_TC->STATUS.bit.SYNCBUSY == 1); // sync
 
 		if (s > 1) {
-			__overflows = _overflows = s / 1,39808;
+			__overflows = _overflows = s / 1.39808;
 			__remaining = _remaining = ((s * 100000) % 139808) * 480 / 1024; // for integer s this is always an integer
 		} else {
 			__overflows = _overflows = 0;

--- a/src/hardware/uTimerLib.SAMD21.cpp
+++ b/src/hardware/uTimerLib.SAMD21.cpp
@@ -85,7 +85,7 @@
 
 		GCLK_TC/1024:
 		freq = 48 MHz / prescaler = 48 MHz / 1024 = 46.875 kHz = 46875 Hz
-		base_delay = 1 / freq = 1 / 46875 s = ~= 21,333333333us
+		base_delay = 1 / freq = 1 / 46875 s = ~= 21.333333333us
 		overflow_delay = UINT16_MAX * base_delay = 65535 / 46875 s = 1.39808 s
 		*/
 
@@ -152,16 +152,16 @@
 		_TC->CTRLA.reg &= ~TC_CTRLA_ENABLE;
 		while (_TC->STATUS.bit.SYNCBUSY == 1); // sync
 
-		// Set Timer counter Mode to 16 bits + Set TC as normal Normal Frq + Prescaler: GCLK_TC/1024
-		_TC->CTRLA.reg |= (TC_CTRLA_MODE_COUNT16 + TC_CTRLA_WAVEGEN_NFRQ + TC_CTRLA_PRESCALER_DIV1024);
+		// Set Timer counter Mode to 16 bits + Set TC as normal Match Frq + Prescaler: GCLK_TC/1024
+		_TC->CTRLA.reg |= (TC_CTRLA_MODE_COUNT16 + TC_CTRLA_WAVEGEN_MFRQ + TC_CTRLA_PRESCALER_DIV1024);
 		while (_TC->STATUS.bit.SYNCBUSY == 1); // sync
 
 		if (s > 1) {
 			__overflows = _overflows = s / 1.39808;
-			__remaining = _remaining = ((s * 100000) % 139808) * 480 / 1024; // for integer s this is always an integer
+			__remaining = _remaining = ((s * 100000) % 139808) * 480 / 1024 - 1; // for integer s this is always an integer
 		} else {
 			__overflows = _overflows = 0;
-			__remaining = _remaining = s * 46875;
+			__remaining = _remaining = s * 46875 - 1;
 		}
 
 		if (__overflows == 0) {

--- a/src/hardware/uTimerLib.SAMD21.cpp
+++ b/src/hardware/uTimerLib.SAMD21.cpp
@@ -158,7 +158,7 @@
 
 		if (s > 1) {
 			__overflows = _overflows = s / 1,39808;
-			__remaining = _remaining = ((s - (1.39808 * _overflows)) * 46875) + 0.5; // +0.5 is same as round
+			__remaining = _remaining = ((s * 100000) % 139808) * 480 / 1024; // for integer s this is always an integer
 		} else {
 			__overflows = _overflows = 0;
 			__remaining = _remaining = s * 46875;

--- a/src/hardware/uTimerLib.SAMD21.cpp
+++ b/src/hardware/uTimerLib.SAMD21.cpp
@@ -52,7 +52,7 @@
 
 		Prescaler:
 		Prescalers: GCLK_TC, GCLK_TC/2, GCLK_TC/4, GCLK_TC/8, GCLK_TC/16, GCLK_TC/64, GCLK_TC/256, GCLK_TC/1024
-		Base frequency: 84MHz
+		Base frequency: 48MHz
 
 		We will use TCC2, as there're some models with only 3 timers (regular models have 5 TCs)
 
@@ -60,13 +60,13 @@
 
 
 		Name			Prescaler	Freq		Base Delay		Overflow delay
-		GCLK_TC			   1		 48MHz		0,020833333us	   1365,333333333us;    1,365333333333ms
-		GCLK_TC/2		   2		 24MHz		0,041666667us	   2730,666666667us;    2,730666666667ms
-		GCLK_TC/4		   4		 12MHz		0,083333333us	   5461,333333333us;    5,461333333333ms
-		GCLK_TC/8		   8		  6MHz		0,166666667us	  10922,666666667us;   10,922666666667ms
+		GCLK_TC			   1		 48MHz		~0,020833333us	   1365,3125us;    1,3653125ms
+		GCLK_TC/2		   2		 24MHz		~0,041666667us	   2730,625us;    2,730625ms
+		GCLK_TC/4		   4		 12MHz		~0,083333333us	   5461,25us;    5,46125ms
+		GCLK_TC/8		   8		  6MHz		~0,166666667us	  10922,5us;   10,9225ms
 		GCLK_TC/16		  16		  3MHz		~0,333333333us	  21845us;   21,845ms
-		GCLK_TC/64		  64		750KHz		1,333333333us	  87381,333311488us;   87,381333311488ms
-		GCLK_TC/256		 256		187,5KHz	5,333333333us	 349525,333311488us;  349,525333311488ms
+		GCLK_TC/64		  64		750KHz		~1,333333333us	  87380us;   87,380ms
+		GCLK_TC/256		 256		187,5KHz	~5,333333333us	 349520us;  349,52ms
 		GCLK_TC/1024	1024		46.875kHz	~21,333333333us	1398080us; 1398,08ms; 1,39808s
 
 		In general:

--- a/src/hardware/uTimerLib.SAMD21.cpp
+++ b/src/hardware/uTimerLib.SAMD21.cpp
@@ -103,10 +103,10 @@
 
 		if (us > 21845) {
 			__overflows = _overflows = us / 21845.0;
-			__remaining = _remaining = (us - (21845 * _overflows)) * 3;
+			__remaining = _remaining = (us - (21845 * _overflows)) * 3 - 1;
 		} else {
 			__overflows = _overflows = 0;
-			__remaining = _remaining = us * 3;
+			__remaining = _remaining = us * 3 - 1;
 		}
 
 		if (__overflows == 0) {


### PR DESCRIPTION
fixed #20

I had a deeper look in your code and find the reason and a solution.
During reading your code I also find a few points which I tried to enhance. And I add some github actions.
Finally, I found the bug.

Using the test scripts provided in #20 leads with the code from this pull request to:

| set value | uTimerLib v1.7.1 | fast_samd21_tc v0.2.3 | uTimerLib v[new] |
| ------ | ------ | ------ | ------ |
| 1000000 us / 1 s | 1000021.33 us | 1000000.00 us | 1000000.00 us |
| 100000 us | 100011.22 us | 100000.00 us | 100001.30 us |
| 10000 us | 10002.66 us | 10000.00 us | 10000.00 us |
| 1000 us | 1002.69 us | 1000.00 us | 1000.00 us |
| 10 us | 12.66 us | 10.00 us| 10.00 us|

The calculation of the base delay was rounded. But it is not necessary to calculate with these rounded values. Using the precise values may enhance the result.

Some of the floating point calculation can be done as integer calculation without any need for rounding. This should enhance precision.

Using `TC_CTRLA_WAVEGEN_MFRQ` instead of `TC_CTRLA_WAVEGEN_NFRQ` makes setting `_TC->COUNT.reg = 0;` unnecessary and fixed the imprecise timing.

* Are the github actions OK? Or do you want to stay on travis only?
* Is the new version number OK?
* Is it OK to add myself as contributor?
